### PR TITLE
Add a Travis CI setting file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+sudo: false
+
+language: rust
+
+rust:
+  - stable
+  - beta
+  - nightly
+
+dist: trusty
+
+cache: cargo
+
+script:
+  - cargo build --all
+  # - cargo test --verbose --all
+
+matrix:
+  allow_failures:
+    - rust: nightly


### PR DESCRIPTION
Example:

- https://travis-ci.org/y-yu/kanils/builds/442798843


### P.S

```
warning: unused `#[macro_use]` import
 --> src/main.rs:1:1
  |
1 | #[macro_use]
  | ^^^^^^^^^^^^
  |
  = note: #[warn(unused_imports)] on by default
```

- 👆 https://travis-ci.org/y-yu/kanils/jobs/442798845#L587