### PR TITLE
use tempfile crate instead of tempdir crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ rustyline = "2"
 regex = "1"
 
 [dev-dependencies]
-tempdir = "^0.3.7"
+tempfile = "3"

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -215,7 +215,7 @@ impl StorageHandle {
 
 #[cfg(test)]
 mod tests {
-    use tempdir::TempDir;
+    use tempfile::Builder;
     use trackable::result::TestResult;
 
     use super::*;
@@ -229,7 +229,7 @@ mod tests {
 
     #[test]
     fn overwrite_works() -> TestResult {
-        let dir = track_io!(TempDir::new("cannyls_test"))?;
+        let dir = track_io!(Builder::new().prefix("cannyls_test").tempdir())?;
         let path = dir.path().join("test.lusf");
 
         let nvm = track_try_unwrap!(FileNvm::create(path, 4_000_000));
@@ -245,7 +245,7 @@ mod tests {
 
     #[test]
     fn delete_works() -> TestResult {
-        let dir = track_io!(TempDir::new("cannyls_test"))?;
+        let dir = track_io!(Builder::new().prefix("cannyls_test").tempdir())?;
         let path = dir.path().join("test.lusf");
 
         let nvm = track_try_unwrap!(FileNvm::create(path, 4_000_000));
@@ -261,7 +261,7 @@ mod tests {
 
     #[test]
     fn puts_and_gets_bytes() -> TestResult {
-        let dir = track_io!(TempDir::new("cannyls_test"))?;
+        let dir = track_io!(Builder::new().prefix("cannyls_test").tempdir())?;
         let path = dir.path().join("test.lusf");
 
         let nvm = track_try_unwrap!(FileNvm::create(path, 4_000_000));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,6 @@
 extern crate trackable;
 extern crate cannyls;
 #[cfg(test)]
-extern crate tempdir;
+extern crate tempfile;
 
 pub mod handle;


### PR DESCRIPTION
Since `tempdir` crate was merged into `tempfile` crate (see https://github.com/rust-lang-deprecated/tempdir), we adapt kanils to `tempfile` crate.