### PR TITLE
CannylsにあるDeleteRange機能を使用可能にした

### DIFF
--- a/src/handle.rs
+++ b/src/handle.rs
@@ -118,6 +118,14 @@ impl StorageHandle {
         println!("delete result => {:?}", result);
     }
 
+    pub fn delete_range(&mut self, start: u128, end: u128) {
+        use std::ops::Range;
+        let start = LumpId::new(start);
+        let end = LumpId::new(end);
+        let result = track_try_unwrap!(self.storage.delete_range(Range { start, end }));
+        println!("delete_range result => {:?}", result);
+    }
+
     pub fn journal_info(&mut self) -> Result<JournalSnapshot, cannyls::Error> {
         self.storage.journal_snapshot()
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,6 +70,12 @@ arg_enum! {
         // kanils Delete --storage=storage_path --key=lumpid
         Delete,
 
+        // 渡された2つのkey start, endによる区間[start, end)に含まれる
+        // keyを（すなわち start <= key < endとなるkey）を全て削除する。
+        // 結果は削除に成功したkeyの配列となる。
+        // kanils RangeDelete --storage=storage_path --start=lumpid --end=lumpid
+        RangeDelete,
+
         // lusfストレージ中のヘッダ情報を出力する
         // ヘッダ情報についての詳細は https://github.com/frugalos/cannyls/wiki/Storage-Format を参照
         // kanils Header --storage=storage_path
@@ -112,6 +118,12 @@ struct Opt {
     #[structopt(long = "key")]
     lumpid: Option<String>,
 
+    #[structopt(long = "start")]
+    lumpid_start: Option<String>,
+
+    #[structopt(long = "end")]
+    lumpid_end: Option<String>,
+
     #[structopt(long = "value")]
     data: Option<String>,
 
@@ -129,6 +141,7 @@ struct Opt {
 ("Embed", "lumpid"), ("Embed", "data"),
 ("Get", "lumpid"),("GetBytes", "lumpid"),
 ("Delete", "lumpid"),
+("RangeDelete", "lumpid_start"), ("RangeDelete", "lumpid_end"),
 ("WBench", "count"),("WBench", "size"),
 ("WRBench", "count"),("WRBench", "size")
 ]"#
@@ -319,6 +332,15 @@ fn main() {
             let mut handle = StorageHandle::create(&opt.storage_path);
             let lumpid_str: String = opt.lumpid.unwrap();
             handle.delete(string_to_u128(&lumpid_str));
+        }
+        Command::RangeDelete => {
+            let mut handle = StorageHandle::create(&opt.storage_path);
+            let lumpid_start_str: String = opt.lumpid_start.unwrap();
+            let lumpid_end_str: String = opt.lumpid_end.unwrap();
+            handle.delete_range(
+                string_to_u128(&lumpid_start_str),
+                string_to_u128(&lumpid_end_str),
+            );
         }
         Command::Dump => {
             let mut handle = StorageHandle::create(&opt.storage_path);


### PR DESCRIPTION
Cannylsには、範囲オブジェクト `[lumpid_start, lumpid_end)` で削除するための機能 `delete_range` https://docs.rs/cannyls/0.9.2/cannyls/storage/struct.Storage.html#method.delete_range がある。
KaniLSではこれを用いることができなかったため、新たに対応した。