### PR TITLE
メジャーバージョンとマイナーバージョンを変更するための機能を追加

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ categories = ["command-line-utilities"]
 license = "MIT"
 
 [dependencies]
+byteorder = { version = "1", features = ["i128"] }
 cannyls = "^0.9"
 clap = "2"
 structopt = "^0.2.11"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+extern crate byteorder;
 #[macro_use]
 extern crate trackable;
 extern crate cannyls;

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,6 +97,16 @@ arg_enum! {
         // 読み込みも行うような、書き込み読み込み混合の簡易ベンチマークツール
         // kanils WRBench --storage=storage_path --count=number --size=number
         WRBench,
+
+        // 与えられた16bit数 versionを用いて、lusfファイルのmajor versionを強制的に書き換える。
+        // 出力は `書き換え前のversion => 書き換え後のversion` となる。
+        // kanils ChangeMajorVersionTo --storage=storage_path --version=u16
+        ChangeMajorVersionTo,
+
+        // 与えられた16bit数 versionを用いて、lusfファイルのminor versionを強制的に書き換える。
+        // 出力は `書き換え前のversion => 書き換え後のversion` となる。
+        // kanils ChangeMinorVersionTo --storage=storage_path --version=u16
+        ChangeMinorVersionTo,
     }
 }
 
@@ -121,6 +131,9 @@ struct Opt {
     #[structopt(long = "size")]
     size: Option<usize>,
 
+    #[structopt(long = "version")]
+    version: Option<u16>,
+
     #[structopt(raw(
         possible_values = "&Command::variants()",
         requires_ifs = r#"&[
@@ -130,7 +143,9 @@ struct Opt {
 ("Get", "lumpid"),("GetBytes", "lumpid"),
 ("Delete", "lumpid"),
 ("WBench", "count"),("WBench", "size"),
-("WRBench", "count"),("WRBench", "size")
+("WRBench", "count"),("WRBench", "size"),
+("ChangeMajorVersionTo", "version"),
+("ChangeMinorVersionTo", "version")
 ]"#
     ))]
     command: Command,
@@ -327,6 +342,14 @@ fn main() {
         Command::Header => {
             let mut handle = StorageHandle::create(&opt.storage_path);
             handle.print_header_info();
+        }
+        Command::ChangeMajorVersionTo => {
+            let new_version = opt.version.unwrap();
+            StorageHandle::change_major_version_to(&opt.storage_path, new_version);
+        }
+        Command::ChangeMinorVersionTo => {
+            let new_version = opt.version.unwrap();
+            StorageHandle::change_minor_version_to(&opt.storage_path, new_version);
         }
         Command::WBench => {
             let count = opt.count.unwrap();


### PR DESCRIPTION
Cannylsの生成したlusfファイル中のヘッダ領域に格納されている
* Major Version
* Minor Version
を強制的に変更するための機能を追加した。
https://github.com/frugalos/cannyls/wiki/Storage-Format#2-%E3%83%98%E3%83%83%E3%83%80%E9%A0%98%E5%9F%9F

# 使い方

## メジャーバージョン変更
```shell
$ kanils ChangeMajorVersionTo --storage test.lusf --version 2
change from 1 to 2
```

## マイナーバージョン変更
kanils ChangeMinorVersionTo --storage test.lusf --version 0
```shell
$ kanils ChangeMinorVersionTo --storage test.lusf --version 0
change from 1 to 0
```