### PR TITLE
Upgrades CannyLS to 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 
 [dependencies]
 byteorder = { version = "1", features = ["i128"] }
-cannyls = "^0.9"
+cannyls = "^0.10"
 clap = "2"
 structopt = "^0.2.11"
 trackable = "^0.2.20"


### PR DESCRIPTION
CannyLS 0.10 をリリースしたためその変更を取り込みます。

`Cargo.lock` がリポジトリにコミットされていないのは一旦無視してください。