### PR TITLE
Adopt Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+edition = "2018"
 name = "kanils"
 version = "1.2.0"
 authors = ["The FrugalOS Developers"]

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -295,7 +295,7 @@ mod tests {
     use trackable::result::TestResult;
 
     use super::*;
-    use handle::StorageHandle;
+    use crate::handle::StorageHandle;
 
     #[test]
     fn overwrite_works() -> TestResult {


### PR DESCRIPTION
Adopt Rust 2018.
https://blog.rust-lang.org/2018/07/27/what-is-rust-2018.html