### PR TITLE
Use String::strip_prefix

### DIFF
--- a/src/handle.rs
+++ b/src/handle.rs
@@ -323,7 +323,7 @@ mod tests {
         let mut handle = StorageHandle::new(storage);
 
         assert!(handle.put_str(0, "hoge").is_ok());
-        assert!(handle.delete_key(0)?, true);
+        assert_eq!(handle.delete_key(0)?, true);
         assert!(handle.get_as_string(0)?.is_none());
 
         Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,10 +168,8 @@ struct Opt {
 /// 0x... --try to convert as hexadecimal number--> u128
 /// otherwise --try to convert as decimal number--> u128
 fn string_to_u128(lumpid_str: &str) -> u128 {
-    if lumpid_str.len() <= 2 {
-        u128::from_str_radix(&lumpid_str, 10).unwrap()
-    } else if lumpid_str.starts_with("0x") {
-        u128::from_str_radix(&lumpid_str[2..], 16).unwrap()
+    if let Some(hex) = lumpid_str.strip_prefix("0x") {
+        u128::from_str_radix(hex, 16).unwrap()
     } else {
         u128::from_str_radix(&lumpid_str, 10).unwrap()
     }


### PR DESCRIPTION
https://rust-lang.github.io/rust-clippy/master/index.html#manual_strip に対応するため。
[`String::strip_prefix`](https://doc.rust-lang.org/std/string/struct.String.html#method.strip_prefix) は rustc 1.45.0 で安定化された。